### PR TITLE
Make the repo binder-compliant

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,4 +24,5 @@ Using it looks like this::
 
 .. image:: sample.png
 
-[![Binder](http://mybinder.org/badge.svg)](beta.mybinder.org/v2/gh/choldgraf/mobilechelonian/master/filepath=try.ipynb)
+.. image:: http://mybinder.org/badge.svg
+   :target: https://beta.mybinder.org/v2/gh/takluyver/mobilechelonian/master?filepath=try.ipynb

--- a/README.rst
+++ b/README.rst
@@ -23,3 +23,5 @@ Using it looks like this::
     t.home()
 
 .. image:: sample.png
+
+[![Binder](http://mybinder.org/badge.svg)](beta.mybinder.org/v2/gh/choldgraf/mobilechelonian/master/filepath=try.ipynb)

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,3 @@
+dependencies:
+  - ipywidgets
+  - IPython

--- a/try.ipynb
+++ b/try.ipynb
@@ -1,0 +1,204 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Here we'll import our Turtle object. This lets us create specific turtles.\n",
+    "from mobilechelonian import Turtle"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Widget Javascript not detected.  It may not be installed or enabled properly.\n"
+     ]
+    },
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "ed449f0b32734e3d9ac0534a674cd12b"
+      }
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# We'll create a new turtle like this. It should open a window with our turtle inside.\n",
+    "t = Turtle()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Controlling your turtle\n",
+    "You can control your turtle's speed, position, and whether it draws a line using a few extra commands.\n",
+    "\n",
+    "Play around with different values below to control the turtle above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# t.speed(N) will control the speed of the turtle when it moves (N from 1 - 10)\n",
+    "t.speed(1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# t.penup() will \"raise the pen\" meaning the turtle won't draw lines anymore\n",
+    "t.penup()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# And this will \"lower the pen\" so the turtle draws when it moves\n",
+    "t.pendown()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# This changes the color of the turtle's path, if the pen is down\n",
+    "t.pencolor(\"red\")  # try \"blue\", \"yellow\", \"brown\", \"black\", \"purple\", \"green\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# This will rotate the turtle counter-clockwise\n",
+    "t.left(90)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# And this rotates the turtle clockwise\n",
+    "t.right(90)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# This makes the turtle move forward\n",
+    "t.forward(100)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Finally, this will bring the turtle back home (to the center)\n",
+    "t.home()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Try drawing different shapes.\n",
+    "\n",
+    "# Keeping track of the turtle's path\n",
+    "You can see the history of the turtle's position here"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[{'b': 0, 'lc': 'black', 'p': 1, 's': 1, 'x': 200, 'y': 200},\n",
+       " {'b': -90, 'lc': 'red', 'p': 1, 's': 1, 'x': 200, 'y': 200},\n",
+       " {'b': 90, 'lc': 'red', 'p': 1, 's': 1, 'x': 200, 'y': 200},\n",
+       " {'b': 0, 'lc': 'red', 'p': 1, 's': 1, 'x': 300.0, 'y': 200.0},\n",
+       " {'b': 0, 'lc': 'red', 'p': 1, 's': 1, 'x': 200, 'y': 200}]"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "t.points"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}


### PR DESCRIPTION
I was speaking with a high-school teacher who wanted to use Binder to teach turtle for his students. To that extent I thought it might be nice to create a Binder link for this repo so that people can quickly play around with it!

This PR adds three main things:

1. A `try.ipynb` notebook that shows some of the functionality of the package and encourages users to experiment.
2. `environment.yml` (I'm using conda because it's simpler to get ipywidgets installed)
3. A Binder badge to `README.rst` so users can click.

If it gets merged, we should switch the org name in the Binder link to `takluyver`

Here's the Binder link itself (for my repo):

https://beta.mybinder.org/v2/gh/choldgraf/mobilechelonian/master?filepath=try.ipynb