### PR TITLE
Compatibility with ipywidgets >= 7.0.0

### DIFF
--- a/mobilechelonian/mobilechelonianjs/turtlewidget.js
+++ b/mobilechelonian/mobilechelonianjs/turtlewidget.js
@@ -1,4 +1,4 @@
-define(['nbextensions/mobilechelonianjs/paper', "jupyter-js-widgets"], function(paperlib, widget){
+define(['nbextensions/mobilechelonianjs/paper', "@jupyter-widgets/base"], function(paperlib, widget){
     
     function TurtleDrawing(canvas_element, grid_button, help_button) {
         this.points = [];

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.rst", "r") as f:
     readme = f.read()
 
 setup(name='mobilechelonian',
-      version='0.4',
+      version='0.5',
       description='Turtles in the Jupyter Notebook',
       long_description = readme,
       author='Thomas Kluyver',

--- a/setup.py
+++ b/setup.py
@@ -21,5 +21,5 @@ setup(name='mobilechelonian',
           'Topic :: Artistic Software',
           'Topic :: Education',
       ],
-      install_requires=['IPython', 'ipywidgets'],
+      install_requires=['IPython', 'ipywidgets>=7.0.0'],
 )


### PR DESCRIPTION
mobilechelonian did not seem to work with ipywidgets >= 7.0.0 anymore (at least, I experienced serious difficulty running it with ipywidgets 7.0.3, and did not succeed with the current official distribution). According to the migration guide for ipywidgets, the Javascript require should now reference `@jupyter-widgets/base` instead of `jupyter-js-widgets` (as of version 7.0).

I made that change, and succesfully ran the modified version of mobilechelonian in a Jupyter environment with ipywidgets 7.0.3. In `setup.py` I made sure that the version of ipywidgets will be updated automatically to version >= 7.0.0 (if necessary). I also bumped the version number of mobilechelonian to 0.5, so people who are dependent on `ipywidgets` <= 6 can still install `mobilechelonian==0.4`.