### PR TITLE
fix module name in "Help!" alert box

### DIFF
--- a/mobilechelonian/mobilechelonianjs/turtlewidget.js
+++ b/mobilechelonian/mobilechelonianjs/turtlewidget.js
@@ -42,7 +42,7 @@ define(['nbextensions/mobilechelonianjs/paper', "@jupyter-widgets/base"], functi
         
         this.help_button = help_button;
         this.help_button.click(function (event){
-            alert("example:\nfrom NewTurtle import Turtle\nt = Turtle()\nt.forward(50)\nfor help:\nhelp(Turtle)");
+            alert("example:\nfrom mobilechelonian import Turtle\nt = Turtle()\nt.forward(50)\nfor help:\nhelp(Turtle)");
         });
         
         // some variable to play with still


### PR DESCRIPTION
importing from `NewTurtle` doesn't work (and probably didn't since 632ab6709f32c43f3c0990263482be49c16541d2 or so)