### PR TITLE
Restore MyBinder working by pinning ipywidgets and installing Notebook 6

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,9 +31,9 @@ Using it looks like this::
 .. image:: sample.png
 
 .. image:: https://mybinder.org/badge_logo.svg
-   :target: https://mybinder.org/v2/gh/fomightez/mobilechelonian/master?filepath=try.ipynb
+   :target: https://mybinder.org/v2/gh/takluyver/mobilechelonian/master?filepath=try.ipynb
 
 
 
 .. |badge| image:: https://mybinder.org/badge_logo.svg
-   :target: https://mybinder.org/v2/gh/fomightez/mobilechelonian/master?filepath=try.ipynb
+   :target: https://mybinder.org/v2/gh/takluyver/mobilechelonian/master?filepath=try.ipynb

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,4 @@
-.. image:: https://mybinder.org/badge_logo.svg
-   :target: https://mybinder.org/v2/gh/fomightez/mobilechelonian/master?filepath=try.ipynb
+|badge|
 
 *"Nevertheless... the turtle moves!"* - Small Gods, by Terry Pratchett
 
@@ -34,3 +33,7 @@ Using it looks like this::
 .. image:: https://mybinder.org/badge_logo.svg
    :target: https://mybinder.org/v2/gh/fomightez/mobilechelonian/master?filepath=try.ipynb
 
+
+
+.. |badge| image:: https://mybinder.org/badge_logo.svg
+   :target: https://mybinder.org/v2/gh/fomightez/mobilechelonian/master?filepath=try.ipynb

--- a/README.rst
+++ b/README.rst
@@ -28,5 +28,5 @@ Using it looks like this::
 
 .. image:: sample.png
 
-.. image:: http://mybinder.org/badge.svg
-   :target: https://beta.mybinder.org/v2/gh/takluyver/mobilechelonian/master?filepath=try.ipynb
+.. image:: https://mybinder.org/badge_logo.sv
+   :target: https://beta.mybinder.org/v2/gh/fomightez/mobilechelonian/master?filepath=try.ipynb

--- a/README.rst
+++ b/README.rst
@@ -28,5 +28,5 @@ Using it looks like this::
 
 .. image:: sample.png
 
-.. image:: https://mybinder.org/badge_logo.sv
+.. image:: https://mybinder.org/badge_logo.svg
    :target: https://beta.mybinder.org/v2/gh/fomightez/mobilechelonian/master?filepath=try.ipynb

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,6 @@
+.. image:: https://mybinder.org/badge_logo.svg
+   :target: https://mybinder.org/v2/gh/fomightez/mobilechelonian/master?filepath=try.ipynb
+
 *"Nevertheless... the turtle moves!"* - Small Gods, by Terry Pratchett
 
 This is a Turtle module for the Jupyter Notebook. It's based on code by
@@ -29,4 +32,5 @@ Using it looks like this::
 .. image:: sample.png
 
 .. image:: https://mybinder.org/badge_logo.svg
-   :target: https://beta.mybinder.org/v2/gh/fomightez/mobilechelonian/master?filepath=try.ipynb
+   :target: https://mybinder.org/v2/gh/fomightez/mobilechelonian/master?filepath=try.ipynb
+

--- a/environment.yml
+++ b/environment.yml
@@ -1,3 +1,7 @@
+name: example-environment
+channels:
+  - conda-forge
 dependencies:
+  - notebook=6
+  - jupyter_server=1
   - ipywidgets == 7.6.5
-  - IPython

--- a/environment.yml
+++ b/environment.yml
@@ -1,3 +1,3 @@
 dependencies:
-  - ipywidgets
+  - ipywidgets == 7.6.5
   - IPython


### PR DESCRIPTION
This is relation to [Issue #28 - Fix to keep working via MyBinder's NbClassic by pinning to old ipywidgets](https://github.com/takluyver/mobilechelonian/issues/28) and [very recent updates to MyBinder's default notebook](https://discourse.jupyter.org/t/notebook-7-on-mybinder-org-and-repo2docker/27924/2?u=fomightez).
This edits `environment.yml` to restore MyBinder sessions to building and launching correctly and displaying/rendering the turtle window when demo notebook is run.

The two changes are pinning ipywidgets to pre-version 8 and to have Notebook 6 installed and used as default JN in sessions launched from this repo.

(This branch keeps the MyBinder badges pointing at `takluyver/mobilechelonian`. I had the main branch pointing at my fork for testing.)